### PR TITLE
Integrate default project and show version

### DIFF
--- a/pipeline-scraper.js
+++ b/pipeline-scraper.js
@@ -528,7 +528,12 @@
       // Get project info
       updateStatus('Getting selected project...');
       const project = await getProjectInfo();
-      
+
+      if (!project.id && typeof CONFIG !== 'undefined' && CONFIG.DEFAULT_PROJECT_ID) {
+        project.id = CONFIG.DEFAULT_PROJECT_ID;
+        project.name = 'Default Project';
+      }
+
       if (!project.id) {
         updateStatus('No project selected. Please select a project in the extension popup.');
         return;

--- a/popup.html
+++ b/popup.html
@@ -189,12 +189,13 @@
           <span id="current-url" style="font-size: 12px; word-break: break-all;"></span>
         </div>
         
-        <div class="btn-group">
-          <button id="logout-button" class="button danger">Log Out</button>
-          <button id="options-button" class="button secondary">Options</button>
-        </div>
+      <div class="btn-group">
+        <button id="logout-button" class="button danger">Log Out</button>
+        <button id="options-button" class="button secondary">Options</button>
+      </div>
       </div>
     </div>
+    <div id="version-info" class="text-center mt-10"></div>
   </div>
   
   <script src="config.js"></script>

--- a/popup.js
+++ b/popup.js
@@ -28,6 +28,12 @@ document.addEventListener('DOMContentLoaded', async () => {
   try {
     // Initialize auth with API base URL from config
     auth = new Auth(CONFIG.API_BASE_URL || 'https://linkedin-profile-scraper.replit.app');
+
+    // Show extension version in the popup
+    const versionEl = document.getElementById('version-info');
+    if (versionEl && CONFIG.VERSION) {
+      versionEl.textContent = `Version ${CONFIG.VERSION}`;
+    }
     
     // Check if user is authenticated
     const isAuthenticated = auth.isAuthenticated();
@@ -201,10 +207,10 @@ async function getCurrentTab() {
 
 // Handle scrape button click
 async function handleScrape() {
-  // Check if a project is selected
-  const projectId = projectSelect.value;
+  // Use selected project or fallback to default
+  const projectId = projectSelect.value || CONFIG.DEFAULT_PROJECT_ID;
   if (!projectId) {
-    showStatus(scrapeStatus, 'Please select a project first', 'error');
+    showStatus(scrapeStatus, 'No project available', 'error');
     return;
   }
   
@@ -248,10 +254,10 @@ async function handleScrape() {
 
 // Handle pipeline scrape button click
 async function handlePipelineScrape() {
-  // Check if a project is selected
-  const projectId = projectSelect.value;
+  // Use selected project or fallback to default
+  const projectId = projectSelect.value || CONFIG.DEFAULT_PROJECT_ID;
   if (!projectId) {
-    showStatus(scrapeStatus, 'Please select a project first', 'error');
+    showStatus(scrapeStatus, 'No project available', 'error');
     return;
   }
   
@@ -270,7 +276,7 @@ async function handlePipelineScrape() {
     // Execute pipeline script on the current tab
     chrome.scripting.executeScript({
       target: {tabId: currentTabId},
-      files: ['pipeline-scraper.js']
+      files: ['config.js', 'pipeline-scraper.js']
     }, () => {
       if (chrome.runtime.lastError) {
         console.error('Script injection error:', chrome.runtime.lastError);


### PR DESCRIPTION
## Summary
- display extension version in the popup
- fallback to default project ID for scraping
- inject config for the pipeline scraper and use the default project ID when nothing is chosen

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684490fa785c832f9844d097c8833556