### PR TITLE
Add options page

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -19,6 +19,7 @@
       "128": "images/icon128.png"
     }
   },
+  "options_page": "options.html",
   "background": {
     "service_worker": "background.js"
   },

--- a/options.html
+++ b/options.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>PharmaTalent Options</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; }
+    label { display:block; margin-bottom:5px; }
+    input { width:100%; padding:8px; margin-bottom:10px; }
+    button { padding:8px 12px; }
+  </style>
+</head>
+<body>
+  <h1>Extension Options</h1>
+  <label for="api-base-url">API Base URL</label>
+  <input type="text" id="api-base-url" placeholder="https://example.com">
+  <button id="save-button">Save</button>
+  <div id="status"></div>
+  <script src="options.js"></script>
+</body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,20 @@
+// Handle options for PharmaTalent extension
+
+document.addEventListener('DOMContentLoaded', () => {
+  const input = document.getElementById('api-base-url');
+  const status = document.getElementById('status');
+
+  // Load saved value
+  chrome.storage.local.get('pt_base_url', (result) => {
+    input.value = result.pt_base_url || 'https://linkedin-profile-scraper.replit.app';
+  });
+
+  // Save button handler
+  document.getElementById('save-button').addEventListener('click', () => {
+    const url = input.value.trim();
+    chrome.storage.local.set({ pt_base_url: url }, () => {
+      status.textContent = 'Options saved.';
+      setTimeout(() => { status.textContent = ''; }, 2000);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a simple options page to set the API base URL
- reference the options page in the manifest

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684490e766bc832f940ccde8d9967fff